### PR TITLE
Bump log4j from 1.2.17 to 2.3

### DIFF
--- a/extras/log4j/pom.xml
+++ b/extras/log4j/pom.xml
@@ -22,9 +22,9 @@
       <artifactId>prevayler-core</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
+      <version>2.3</version>
       <exclusions>
         <exclusion>
           <groupId>javax.jms</groupId>


### PR DESCRIPTION
This is the latest version that supports Java 6.

Fixes #24